### PR TITLE
Add X-Forwarded-For header in proxy to API server.

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -35,6 +35,7 @@ app.use(express.static(path.join(__dirname, '..', 'static')));
 
 app.use((req, res, next) => {
   res.setHeader('Service-Worker-Allowed', '*');
+  res.setHeader('X-Forwarded-For', req.ip);
   return next();
 });
 


### PR DESCRIPTION
Add X-Forwarded-For header so that the API server has the proper end-user IP address in the `req.ip` field.