### PR TITLE
Delaying service worker's registration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -116,7 +116,8 @@ Promise.all([window.__data ? true : isOnline(), getStoredState(offlinePersistCon
   }
 
   if (online && !__DEVELOPMENT__ && 'serviceWorker' in navigator) {
-    navigator.serviceWorker
+    window.addEventListener('load', () => {
+      navigator.serviceWorker
       .register('/dist/service-worker.js', { scope: '/' })
       .then(() => {
         console.log('Service worker registered!');
@@ -125,10 +126,11 @@ Promise.all([window.__data ? true : isOnline(), getStoredState(offlinePersistCon
         console.log('Error registering service worker: ', error);
       });
 
-    navigator.serviceWorker.ready.then(
-      (/* registration */) => {
-        console.log('Service Worker Ready');
-      }
-    );
+      navigator.serviceWorker.ready.then(
+        (/* registration */) => {
+          console.log('Service Worker Ready');
+        }
+      );
+    });
   }
 });

--- a/src/client.js
+++ b/src/client.js
@@ -118,13 +118,13 @@ Promise.all([window.__data ? true : isOnline(), getStoredState(offlinePersistCon
   if (online && !__DEVELOPMENT__ && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
       navigator.serviceWorker
-      .register('/dist/service-worker.js', { scope: '/' })
-      .then(() => {
-        console.log('Service worker registered!');
-      })
-      .catch(error => {
-        console.log('Error registering service worker: ', error);
-      });
+        .register('/dist/service-worker.js', { scope: '/' })
+        .then(() => {
+          console.log('Service worker registered!');
+        })
+        .catch(error => {
+          console.log('Error registering service worker: ', error);
+        });
 
       navigator.serviceWorker.ready.then(
         (/* registration */) => {


### PR DESCRIPTION
Deferring service worker's initial registration until after the initial page has loaded will provide the best experience for users, here's the explanation article [Service Worker Registration](https://developers.google.com/web/fundamentals/instant-and-offline/service-worker/registration?hl=en-US).