### PR TITLE
reducing the bundle size by importing only lodash/pick

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -2,7 +2,7 @@
  * THIS IS THE ENTRY POINT FOR THE CLIENT, JUST LIKE server.js IS THE ENTRY POINT FOR THE SERVER.
  */
 import 'babel-polyfill';
-import _ from 'lodash';
+import pick from 'lodash/pick';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { ConnectedRouter } from 'react-router-redux';
@@ -63,7 +63,7 @@ initSocket();
   const data = {
     ...storedData,
     ...window.__data,
-    ..._.pick(storedData, [
+    ...pick(storedData, [
       /* data always from store */
     ]),
     online


### PR DESCRIPTION
As we use Lodash only here, it is best to minimize the size of the bundle by only importing `pick` otherwise, as you can see, lodash takes a huge percentage of the bundle's size
![screen shot 2018-05-08 at 10 38 44](https://user-images.githubusercontent.com/1489292/39748916-abad7340-52b1-11e8-8c41-a9d75ffde351.png)
