### PR TITLE
fix CJK characters cause a 301 redirect loop

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -177,7 +177,7 @@ app.use(async (req, res) => {
     }
 
     const locationState = store.getState().router.location;
-    if (req.originalUrl !== locationState.pathname + locationState.search) {
+    if (decodeURIComponent(req.originalUrl) !== decodeURIComponent(locationState.pathname + locationState.search)) {
       return res.redirect(301, locationState.pathname);
     }
 


### PR DESCRIPTION
Hello,

For example, open the `http://localhost:3000/你好`,
Google Chrome will receive an error: ERR_TOO_MANY_REDIRECTS

Thanks