### PR TITLE
client-side: don't fetch data for initial route

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -86,7 +86,14 @@ initSocket();
       location: history.location
     };
 
-    await trigger('fetch', components, triggerLocals);
+    // Don't fetch data for initial route, server has already done the work:
+    if (window.__PRELOADED__) {
+      // Delete initial data so that subsequent data fetches can occur:
+      delete window.__PRELOADED__;
+    } else {
+      // Fetch mandatory data dependencies for 2nd route change onwards:
+      await trigger('fetch', components, triggerLocals);
+    }
     await trigger('defer', components, triggerLocals);
 
     ReactDOM.hydrate(

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -59,7 +59,9 @@ const Html = ({
         <div id="content" dangerouslySetInnerHTML={{ __html: content }} />
         {store && (
           <script
-            dangerouslySetInnerHTML={{ __html: `window.__data=${serialize(store.getState())};` }}
+            dangerouslySetInnerHTML={{
+              __html: `window.__PRELOADED__=true;window.__data=${serialize(store.getState())};`
+            }}
             charSet="UTF-8"
           />
         )}


### PR DESCRIPTION
Hello,

This PR for bypass client-side initial route data fetch calls, and prevent double api fetch for improve performance.

[Reference](https://github.com/markdalgleish/redial/blob/master/README.md#example-client-usage)