### PR TITLE
comparing location properly with pathname and search

### DIFF
--- a/src/components/ReduxAsyncConnect/ReduxAsyncConnect.js
+++ b/src/components/ReduxAsyncConnect/ReduxAsyncConnect.js
@@ -25,7 +25,10 @@ class ReduxAsyncConnect extends Component {
     const {
       history, location, routes, store, helpers
     } = this.props;
-    const navigated = nextProps.location !== location;
+    const {
+      location: { pathname, search }
+    } = nextProps;
+    const navigated = `${pathname}${search}` !== `${location.pathname}${location.search}`;
 
     if (navigated) {
       // save the location so we can render the old screen


### PR DESCRIPTION
Bug fix:  Equality check for the object to object won't work
Checking with the pathname and search in nextProps and props
